### PR TITLE
V0.1.6

### DIFF
--- a/cash-register.css
+++ b/cash-register.css
@@ -15,7 +15,7 @@ body {
 h1 {
   display: block;
   background: linear-gradient(75deg, #fcc, #cff);
-  margin: 10vh auto;
+  margin: 5vh auto;
   padding: 4px;
   max-width: 550px;
   border: thick solid white;
@@ -30,10 +30,17 @@ h1 {
     "hundred twenty ten five dollar"
     "quarter dime nickel penny total";
   border: 1px solid;
+  box-shadow: 0 2px 6px 2px rgba(0,0,0,0.2); 
 }
 
 .cash-container {
   border: thin solid black;
+}
+
+.cash-container p:first-child {
+  line-height: 12px;
+  font-size: 0.9em;
+  color: #333;
 }
 
 .empty-cash {
@@ -46,6 +53,8 @@ h1 {
 }
 
 .cash-value {
+  line-height: 32px;
+  font-size: 1.1em;
   font-weight: bold;
 }
 
@@ -54,20 +63,33 @@ h1 {
   margin: 12px auto;
   justify-content: space-evenly;
   align-items: center;
+/*   box-shadow: 0 2px 6px 2px rgba(0,0,0,0.2); */
 }
 
 .button {
   background: gray;
   display: inline-block;
-  margin: 24px auto 12px auto;
+/*   margin: 24px auto 12px auto; */
+  width: 50px;
   height: 50px;
   line-height: 50px;
-  width: 50px;
+  border: 1px solid;
+  box-shadow: 0 2px 6px 2px rgba(0,0,0,0.2);
   cursor: pointer;
 }
 
-.pay-button {
-  
+.button:hover {
+  background: lightgray;
+}
+
+/*  Doesn't transform so well with text; goes blurry and transition is too small to be useful. */
+ .hover-shadow {
+  transition: transform 60ms;
+}
+
+.hover-shadow:hover {
+  box-shadow: 0 0 6px 0px rgba(0,0,0,0.5);
+  transform: scale(1.04);
 }
 
 #set-cash {
@@ -75,8 +97,10 @@ h1 {
 }
 
 #payment-input-value {
-  line-height: 2.6em;
-  width: 120px;
+/*   line-height: 2.5em; */
+  display: inline-block;
+  padding: 13px 4px;
+  width: 130px;
   font-size: 18px;
   text-align: right;
 }
@@ -118,12 +142,24 @@ h1 {
 }
 
 .summary-button {
-  background: yellow;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
   padding: 12px;
   border: thin solid;
   border-radius: 5px;
+  font-size: 18px;
+  font-weight: bold;
   cursor: pointer;
 }
+
+/*.button-text {
+   display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+} */
 
 #receipt-display {
   grid-area: receipt;
@@ -134,12 +170,21 @@ h1 {
 }
 
 #print-receipt-button {
+  background: yellow;
   grid-area: button1;
+}
+
+#print-receipt-button:hover {
+  background: #ffff5b;
 }
 
 #next-customer-button {
   background: orange;
   grid-area: button2;
+}
+
+#next-customer-button:hover {
+  background: #ffc666;
 }
 
 ul {
@@ -162,6 +207,10 @@ ul {
   text-align: left;
 }
 
+#summary-lists li {
+  margin: 12px auto;
+}
+
 #summary-subject {
   font-weight: bold;
 }
@@ -172,10 +221,14 @@ ul {
   text-align: right;
 }
 
-#bottom-row-container {
+#top-row-container {
+  background: white;
   position: relative;
   display: flex;
-  margin: 24px auto;
+  margin: auto;
+  padding: 3px;
+  box-shadow: 0 2px 6px 2px rgba(0,0,0,0.2); 
+  border: 2px solid;
 }
 
 #button-blocker {
@@ -188,36 +241,50 @@ ul {
   left: 0;
 }
 
+/* Both side-boxes have an "order" value so they
+can be switched easily. Items on left seems more
+intuitive as filling the basket is the first step,
+however people using the system would most likely
+be right-handed and with the items/keys on the right,
+they could see what the display was reading on the left. */
 .side-box {
-  width: 50%;
+  width: 49.8%;
+  margin: 0 auto;
 }
 
 #sellable-items {
   background: orange;
-/*   display: flex;
-  flex-flow: row wrap;
-  justify-content: space-evenly;
-  align-content: space-evenly; */
+  order: 1;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: repeat(2, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  grid-gap: 14px;
+  padding: 14px;
   align-items: center;
   justify-items: center;
+  border: 2px solid;
 }
 
 .item {
   background: lightblue;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   border: thin solid;
-  height: 70%;
-  width: 70%;
-/*   height: auto; */
-/*   width: auto; */
+  height: 100%;
+  width: 100%;
   cursor: pointer;
 }
 
+.item:hover {
+  background: #c3ebf7;
+}
+
 #number-displays {
-  background: green;
+  background: #0dbf0d;
+  order: 0;
   padding: auto 20px;
+  border: 2px solid;
 }
 
 #number-displays div {

--- a/index.html
+++ b/index.html
@@ -12,8 +12,99 @@
 <body>
   <h1>JavaScript Cash Register</h1>
   
+  
+  
+  <div id="top-row-container">
+    <div id="button-blocker"></div>
+    <div id="sellable-items" class="side-box">
+      <div id="apple" class="item hover-shadow">Apple</div>
+      <div id="banana" class="item hover-shadow">Banana</div>
+      <div id="crisps" class="item hover-shadow">Crisps</div>
+      <div id="drink" class="item hover-shadow">Drink</div>
+      <div id="energybar" class="item hover-shadow">Energy Bar</div>
+      <div id="fish" class="item hover-shadow">Fish</div>
+      <div id="grapes" class="item hover-shadow">Grapes</div>
+      <div id="halloumi" class="item hover-shadow">Halloumi</div>
+      <div id="ice" class="item hover-shadow">Ice</div>
+    </div>
+    
+    <div id="number-displays" class="side-box">
+      <div id="price-display">
+        <h2>Price:</h2>
+        <p id="price-value" class="results-display">0.00</p>
+      </div>
+
+      <div id="payment-display">
+        <h2>Cash given:</h2>
+        <p id="payment-value" class="results-display">0.00</p>
+      </div>
+
+      <div id="change-due-display">
+        <h2>Change due:</h2>
+        <p id="change-due-value" class="results-display">0.00</p>
+        <p id="change-due-array"></p>
+      </div>
+
+      <div id="status-display">
+        <h2>Status:</h2>
+        <p id="status">OPEN</p>
+      </div>
+    </div>
+  </div>
+  
+  
+  
+  <div id="button-container">
+    <div>
+      <div id="set-cash" class="button hover-shadow">Count Cash</div>
+    </div>
+    
+    <div id="payment-buttons">
+      <div id="hundred" class="pay-button button hover-shadow">100</div>
+      <div id="twenty" class="pay-button button hover-shadow">20</div>
+      <div id="ten" class="pay-button button hover-shadow">10</div>
+      <div id="five" class="pay-button button hover-shadow">5</div>
+      <div id="dollar" class="pay-button button hover-shadow">1</div>
+    </div>
+    
+    <div id="payment-input">
+      <input id="payment-input-value" name="payment-input-value" type="text" placeholder="Cash given:">
+      <label id="pay" name="payment-input-value" for="payment-input-value" class="button pay-button hover-shadow">Pay</label>
+    </div>
+    
+    <div id="sale-summary-display">
+      <div id="receipt-display" class="summary-display">
+        <h4>Shopping Centre</h4>
+        <p>Thank you, see you again!</p><hr>
+        <div id="receipt-lists" class="list-container">
+          <ul id="receipt-goods"></ul>
+          <ul id="receipt-price"></ul>
+        </div>
+      </div>
+      <div id="print-receipt-button" class="summary-button hover-shadow">Print Receipt</div>
+      
+      <div id="payment-summary-display" class="summary-display">
+        <h4>Sale Summary</h4>
+        <p>Thank you, see you again!</p><hr>
+        <div id="summary-lists" class="list-container">
+          <ul id="summary-subject">
+            <li>Till status:</li>
+            <li>Price:</li>
+            <li>Cash paid:</li>
+            <li>Change due:</li>
+            <li>Coins returned:</li>
+          </ul>
+          <ul id="summary-detail"></ul>
+        </div>
+      </div>
+      <div id="next-customer-button" class="summary-button hover-shadow">Continue</div>
+    </div>
+  </div>
+  
+  
+  
   <div id="cash-in-drawer-display">
-    <h2>Cash in drawer:</h2>
+<!--     <h2>Cash in drawer:</h2> -->
     <div id="cash-in-drawer-grid">
       <div id="hundred-container" class="cash-container">
         <p class="denomination-value">100</p><hr>
@@ -61,96 +152,15 @@
       </div>
       
       <div id="total-container" class="cash-container">
-        <p>TOTAL:</p><hr>
+        <p style="font-weight: bold">TOTAL:</p><hr>
         <p id="total-cash-value" class="cash-value"></p>
       </div>
     </div>
   </div>
   
   
-  <div id="button-container">
-    <div>
-      <div id="set-cash" class="button">Count Cash</div>
-    </div>
-    
-    <div id="payment-buttons">
-      <div id="hundred" class="pay-button button">100</div>
-      <div id="twenty" class="pay-button button">20</div>
-      <div id="ten" class="pay-button button">10</div>
-      <div id="five" class="pay-button button">5</div>
-      <div id="dollar" class="pay-button button">1</div>
-    </div>
-    
-    <div id="payment-input">
-      <input id="payment-input-value" name="payment-input-value" type="text" placeholder="Cash given:">
-      <label id="pay" name="payment-input-value" for="payment-input-value" class="button pay-button">Pay</label>
-    </div>
-    
-    <div id="sale-summary-display">
-      <div id="receipt-display" class="summary-display">
-        <h4>Shopping Centre</h4>
-        <p>Thank you, see you again!</p><hr>
-        <div id="receipt-lists" class="list-container">
-          <ul id="receipt-goods"></ul>
-          <ul id="receipt-price"></ul>
-        </div>
-      </div>
-      <div id="print-receipt-button" class="summary-button">Print Receipt</div>
-      
-      <div id="payment-summary-display" class="summary-display">
-        <h4>Sale Summary</h4>
-        <p>Thank you, see you again!</p><hr>
-        <div id="summary-lists" class="list-container">
-          <ul id="summary-subject">
-            <li>Till status:</li>
-            <li>Price:</li>
-            <li>Cash paid:</li>
-            <li>Change due:</li>
-            <li>Coins returned:</li>
-          </ul>
-          <ul id="summary-detail"></ul>
-        </div>
-      </div>
-      <div id="next-customer-button" class="summary-button">Continue</div>
-    </div>
-  </div>
-  
-  <div id="bottom-row-container">
-    <div id="button-blocker"></div>
-    <div id="sellable-items" class="side-box">
-      <div id="apple" class="item">Apple</div>
-      <div id="banana" class="item">Banana</div>
-      <div id="crisps" class="item">Crisps</div>
-      <div id="drink" class="item">Drink</div>
-      <div id="energybar" class="item">Energy Bar</div>
-      <div id="feta" class="item">Feta</div>
-    </div>
-    
-    <div id="number-displays" class="side-box">
-      <div id="price-display">
-        <h2>Price:</h2>
-        <p id="price-value" class="results-display">0.00</p>
-      </div>
-
-      <div id="payment-display">
-        <h2>Cash given:</h2>
-        <p id="payment-value" class="results-display">0.00</p>
-      </div>
-
-      <div id="change-due-display">
-        <h2>Change due:</h2>
-        <p id="change-due-value" class="results-display">0.00</p>
-        <p id="change-due-array"></p>
-      </div>
-
-      <div id="status-display">
-        <h2>Status:</h2>
-        <p id="status">OPEN</p>
-      </div>
-    </div>
-  </div>
   
   
-  <script src="cash-register.js" type="text/javascript"></script>
+   <script src="cash-register.js" type="text/javascript"></script>
 
 </body>


### PR DESCRIPTION
**HTML:**
Changed layout to feel more intuitive: screens are now above cash drawers.

**CSS:**
General styling: green display background shade change, title margin changed to fit on one page, box-shadows added to make it seem less flat, cash drawer cash-labels made smaller and drawers made bigger.
Added hover interactivity on buttons etc.
Changed button displays to flex to align text vertically.
Spaced out the summary details.
Added a white border around the main screen displays.
Added an order value to each side-box/display for easy altering: right now, the item buttons are on the right and the screen is on the left. Though it seems more intuitive to have the buttons on the left (sa they're the first things you use - add them to add to basket), for the prospective cashier, the buttons on the right would let them see the screen whilst typing with the buttons (as most people are right-handed).
Changed the sellable-item container to grid.

**JS:**
Added some new items.
Changed order of the blocks in runPayment to have the escape statements together at the beginning (so that they don't disrupt the flow when reading).
Put the myriad createSummaryItem invocations into openSummaryDisplay to clean up the main payment function.
Changed updateCashInDrawer to add the payment value to the relevant coin.
--NOTE: This only works when paying with a value that matches exactly a coin/note denomination. Next up is to make a map/reduce to sift out the coins one by one from the payment and place them into the relevant drawers. After that, I will make a random function determine whether to place the whole note or small coins into the drawers.